### PR TITLE
Fix notifications bug

### DIFF
--- a/app/src/main/java/com/uid/smartmobilityapp/ui/notifications/NotificationPublisher.kt
+++ b/app/src/main/java/com/uid/smartmobilityapp/ui/notifications/NotificationPublisher.kt
@@ -59,7 +59,7 @@ class NotificationPublisher : BroadcastReceiver() {
         }
         destinationIntent.putExtra(UserActivity.destinationFragmentIdExtraName, destination)
         // Create an Intent for the activity you want to start
-        val resultIntent = PendingIntent.getActivity(context, 0, destinationIntent, PendingIntent.FLAG_IMMUTABLE);
+        val resultIntent = PendingIntent.getActivity(context, 0, destinationIntent, PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ONE_SHOT);
 
         builder.setContentIntent(resultIntent)
         return builder.build()


### PR DESCRIPTION
In the current version, both types of notifications (for regular and flexible intents) open up the "My Flexible Intents" fragment.
In the new version, each notification leads to the corresponding fragment (Get Grocesries -> My Flexible Intents. Supermarket Trip -> My Regular Intents).