### PR TITLE
Add notification id to separate the notification parameters

### DIFF
--- a/app/src/main/java/com/uid/smartmobilityapp/ui/notifications/NotificationPublisher.kt
+++ b/app/src/main/java/com/uid/smartmobilityapp/ui/notifications/NotificationPublisher.kt
@@ -31,7 +31,9 @@ class NotificationPublisher : BroadcastReceiver() {
             context,
             intent.getStringExtra(EXTRA_TITLE),
             intent.getStringExtra(EXTRA_CONTENT),
-            intent.getStringExtra(EXTRA_CHANNEL_ID))
+            intent.getStringExtra(EXTRA_CHANNEL_ID),
+            intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
+        )
 
         val id = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
 
@@ -39,7 +41,7 @@ class NotificationPublisher : BroadcastReceiver() {
         manager.notify(id, notification)
     }
 
-    private fun getNotification(context: Context, title: String?, content: String?, channelId: String?): Notification {
+    private fun getNotification(context: Context, title: String?, content: String?, channelId: String?, notificationId: Int): Notification {
         Log.d("NotificationPublisher", "ChannelId: $channelId title: $title content: $content")
         val builder: NotificationCompat.Builder =
             NotificationCompat.Builder(context, channelId!!)
@@ -58,8 +60,9 @@ class NotificationPublisher : BroadcastReceiver() {
             destination = R.id.nav_flexible_intents
         }
         destinationIntent.putExtra(UserActivity.destinationFragmentIdExtraName, destination)
+        Log.d("NotificationPublisher", "Set initial fragment for " + title + ": "  + destination)
         // Create an Intent for the activity you want to start
-        val resultIntent = PendingIntent.getActivity(context, 0, destinationIntent, PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ONE_SHOT);
+        val resultIntent = PendingIntent.getActivity(context, notificationId, destinationIntent, PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ONE_SHOT);
 
         builder.setContentIntent(resultIntent)
         return builder.build()

--- a/app/src/main/java/com/uid/smartmobilityapp/ui/notifications/model/IntentNotificationsQueue.kt
+++ b/app/src/main/java/com/uid/smartmobilityapp/ui/notifications/model/IntentNotificationsQueue.kt
@@ -6,6 +6,6 @@ import java.time.LocalDateTime
 object IntentNotificationsQueue {
     val notifications: ArrayList<IntentNotification> = arrayListOf(
         IntentNotification(1, "Get Groceries", "You should depart at 14:20, by car, to spend the least time in traffic. Expected arrival time: 14:29", NotificationChannelTypes.FLEXIBLE_INTENT_NOTIFICATIONS_CHANNEL, LocalDateTime.now().plusSeconds(3)),
-        IntentNotification(2, MyRegularIntents.regularIntents.get(0), "You should depart at 16:25 to arrive on time", NotificationChannelTypes.REGULAR_INTENT_NOTIFICATIONS_CHANNEL, LocalDateTime.now().plusMinutes(1)),
+        IntentNotification(2, MyRegularIntents.regularIntents.get(0), "You should depart at 16:25 to arrive on time", NotificationChannelTypes.REGULAR_INTENT_NOTIFICATIONS_CHANNEL, LocalDateTime.now().plusSeconds(15)),
     )
 }


### PR DESCRIPTION
This fixes the bug of the "Supermarket" notification opening the flexible intents fragment in case the user opens the "Supermarket" notification before the "Get Groceries" one.